### PR TITLE
Bugfix/typo fix

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,2 +1,2 @@
 ## About Section
-This section gives information about the project.
+This section gives information about the project of git.

--- a/about.md
+++ b/about.md
@@ -1,2 +1,2 @@
 ## About Section
-This section gives information about the project of git.
+This section gives information about the project of github.


### PR DESCRIPTION
## Summary
Corrected a typo where "Git" was mistakenly used instead of "GitHub" in the documentation.

## Changes
- Updated the term from "Git" to "GitHub" in about.md

## Reason
To ensure accuracy in the documentation and avoid confusion between Git (version control system) and GitHub (online platform for Git repositories).
